### PR TITLE
Fix Us states classes

### DIFF
--- a/src/Holiday/InLineHolidayService.php
+++ b/src/Holiday/InLineHolidayService.php
@@ -9,6 +9,9 @@ class InLineHolidayService
 
     public static function checkInLineHoliday(Holiday $holiday, array $holidays, InLineHolidayRules $rules): array
     {
+        self::$isSunday = false;
+        self::$isSaturday = false;
+
         $holidays[] = $holiday;
 
         if ($rules->areRulesApplied()) {
@@ -40,7 +43,7 @@ class InLineHolidayService
     private static function checkForWeekend($time): void
     {
         $weekday = $time->format('N');
-        switch ($weekday) {
+        switch ((int)$weekday) {
             case 6:
                 self::$isSaturday = true;
                 break;

--- a/src/Holiday/Us/Us.php
+++ b/src/Holiday/Us/Us.php
@@ -62,13 +62,13 @@ class Us extends Calculator
             $holidays = InLineHolidayService::checkInLineHoliday($juneteenth, $holidays, new InLineHolidayRules(true, false,true, true));
         }
 
-        $independenceDay = new Holiday(new \DateTimeImmutable($year.'-7-4', $this->timezone), 'Independence Day', $this->timezone);
+        $independenceDay = new Holiday(new \DateTimeImmutable($year.'-07-04', $this->timezone), 'Independence Day', $this->timezone);
         $holidays = InLineHolidayService::checkInLineHoliday($independenceDay, $holidays, new InLineHolidayRules(true, false,true, true));
 
         $veteransDay = new Holiday(new \DateTimeImmutable($year.'-11-11', $this->timezone), 'Veterans Day', $this->timezone);
         $holidays = InLineHolidayService::checkInLineHoliday($veteransDay, $holidays, new InLineHolidayRules(true, false,true, true));
 
-        $newYearsDay = new Holiday($year.'-1-1', "New Year's Day", $this->timezone);
+        $newYearsDay = new Holiday($year.'-01-01', "New Year's Day", $this->timezone);
         $holidays = InLineHolidayService::checkInLineHoliday($newYearsDay, $holidays, new InLineHolidayRules(true, false,true, true));
 
         $holidays[] = new Holiday($christmas->modify('-1 day'), 'Christmas Eve', $this->timezone);

--- a/src/Holiday/Us/UsAk.php
+++ b/src/Holiday/Us/UsAk.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsAk extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsAl.php
+++ b/src/Holiday/Us/UsAl.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsAl extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsAr.php
+++ b/src/Holiday/Us/UsAr.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsAr extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsAz.php
+++ b/src/Holiday/Us/UsAz.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsAz extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsCa.php
+++ b/src/Holiday/Us/UsCa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsCa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsCo.php
+++ b/src/Holiday/Us/UsCo.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsCo extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsCt.php
+++ b/src/Holiday/Us/UsCt.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsCt extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsDc.php
+++ b/src/Holiday/Us/UsDc.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsDc extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsDe.php
+++ b/src/Holiday/Us/UsDe.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsDe extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsFl.php
+++ b/src/Holiday/Us/UsFl.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsFl extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsGa.php
+++ b/src/Holiday/Us/UsGa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsGa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsHi.php
+++ b/src/Holiday/Us/UsHi.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsHi extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsIa.php
+++ b/src/Holiday/Us/UsIa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsIa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsId.php
+++ b/src/Holiday/Us/UsId.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsId extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsIl.php
+++ b/src/Holiday/Us/UsIl.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsIl extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsIn.php
+++ b/src/Holiday/Us/UsIn.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsIn extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsKs.php
+++ b/src/Holiday/Us/UsKs.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsKs extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsKy.php
+++ b/src/Holiday/Us/UsKy.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsKy extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsLa.php
+++ b/src/Holiday/Us/UsLa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsLa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMa.php
+++ b/src/Holiday/Us/UsMa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMd.php
+++ b/src/Holiday/Us/UsMd.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMd extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMe.php
+++ b/src/Holiday/Us/UsMe.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMe extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMi.php
+++ b/src/Holiday/Us/UsMi.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMi extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMn.php
+++ b/src/Holiday/Us/UsMn.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMn extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMo.php
+++ b/src/Holiday/Us/UsMo.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMo extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMs.php
+++ b/src/Holiday/Us/UsMs.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMs extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsMt.php
+++ b/src/Holiday/Us/UsMt.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsMt extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNc.php
+++ b/src/Holiday/Us/UsNc.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNc extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNd.php
+++ b/src/Holiday/Us/UsNd.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNd extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNe.php
+++ b/src/Holiday/Us/UsNe.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNe extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNh.php
+++ b/src/Holiday/Us/UsNh.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNh extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNj.php
+++ b/src/Holiday/Us/UsNj.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNj extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNm.php
+++ b/src/Holiday/Us/UsNm.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNm extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNv.php
+++ b/src/Holiday/Us/UsNv.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNv extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsNy.php
+++ b/src/Holiday/Us/UsNy.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsNy extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsOh.php
+++ b/src/Holiday/Us/UsOh.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsOh extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsOk.php
+++ b/src/Holiday/Us/UsOk.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsOk extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsOr.php
+++ b/src/Holiday/Us/UsOr.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsOr extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsPa.php
+++ b/src/Holiday/Us/UsPa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsPa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsRi.php
+++ b/src/Holiday/Us/UsRi.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsRi extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsSc.php
+++ b/src/Holiday/Us/UsSc.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsSc extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsSd.php
+++ b/src/Holiday/Us/UsSd.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsSd extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsTn.php
+++ b/src/Holiday/Us/UsTn.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsTn extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsTx.php
+++ b/src/Holiday/Us/UsTx.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsTx extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsUt.php
+++ b/src/Holiday/Us/UsUt.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsUt extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsVa.php
+++ b/src/Holiday/Us/UsVa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsVa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsVt.php
+++ b/src/Holiday/Us/UsVt.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsVt extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsWa.php
+++ b/src/Holiday/Us/UsWa.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsWa extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsWi.php
+++ b/src/Holiday/Us/UsWi.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsWi extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsWv.php
+++ b/src/Holiday/Us/UsWv.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsWv extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/src/Holiday/Us/UsWy.php
+++ b/src/Holiday/Us/UsWy.php
@@ -19,7 +19,7 @@ use Holiday\Holiday;
 
 class UsWy extends Us
 {
-    protected function getPublicHolidays($year)
+    protected function getHolidays($year): array
     {
         $holidays = parent::getHolidays($year);
 

--- a/tests/Holiday/Us/UsDcTest.php
+++ b/tests/Holiday/Us/UsDcTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 3 as published by the Free Software Foundation
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * @copyright  Copyright (c) 2012 Mayflower GmbH (http://www.mayflower.de)
+ * @license    LGPL v3 (See LICENSE file)
+ */
+namespace Tests\Holiday\Us;
+
+use Holiday\Us\UsDc;
+use PHPUnit\Framework\TestCase;
+
+class UsDcTest extends TestCase
+{
+    private ?UsDc $holiday = null;
+
+    private ?\DateTimeZone $timezone = null;
+
+    public function setUp(): void
+    {
+        $this->timezone = new \DateTimeZone('UTC');
+        $this->holiday = new UsDc($this->timezone);
+    }
+
+    public function testInaugurationDayIsHoliday()
+    {
+        $inaugurationDate = new \DateTime('2009-01-20', $this->timezone);
+
+        $this->assertEquals(true, count($this->holiday->isHoliday($inaugurationDate)) > 0, 'First Inauguration Barack Obama');
+
+        $inaugurationDate = new \DateTime('2013-01-20', $this->timezone);
+
+        $this->assertEquals(true, count($this->holiday->isHoliday($inaugurationDate)) > 0, 'Second Inauguration Barack Obama');
+
+        $inaugurationDate = new \DateTime('2021-01-20', $this->timezone);
+
+        $this->assertEquals(true, count($this->holiday->isHoliday($inaugurationDate)) > 0, 'Inauguration Joe Biden');
+
+    }
+}

--- a/tests/Holiday/Us/UsDcTest.php
+++ b/tests/Holiday/Us/UsDcTest.php
@@ -42,6 +42,5 @@ class UsDcTest extends TestCase
         $inaugurationDate = new \DateTime('2021-01-20', $this->timezone);
 
         $this->assertEquals(true, count($this->holiday->isHoliday($inaugurationDate)) > 0, 'Inauguration Joe Biden');
-
     }
 }

--- a/tests/Holiday/Us/UsMiTest.php
+++ b/tests/Holiday/Us/UsMiTest.php
@@ -14,19 +14,19 @@
  */
 namespace Tests\Holiday\Us;
 
-use Holiday\Us\Us;
+use Holiday\Us\UsMi;
 use PHPUnit\Framework\TestCase;
 
-class UsTest extends TestCase
+class UsMiTest extends TestCase
 {
-    private ?Us $holiday = null;
+    private ?UsMi $holiday = null;
 
     private ?\DateTimeZone $timezone = null;
 
     public function setUp(): void
     {
         $this->timezone = new \DateTimeZone('UTC');
-        $this->holiday = new Us($this->timezone);
+        $this->holiday = new UsMi($this->timezone);
     }
 
     public function testIsHoliday()
@@ -61,12 +61,6 @@ class UsTest extends TestCase
         $this->assertEquals(true, count($this->holiday->isHoliday($veteransDay)) > 0, 'Veterans Day Failed');
         $this->assertEquals(true, count($this->holiday->isHoliday($columbusDay)) > 0, 'Columbus Day Failed');
         $this->assertNotEquals(true, count($this->holiday->isHoliday($dummyDate)) > 0, 'Dummy Date Test Failed');
-    }
-
-    public function testInaugurationIsNotAPublicHoliday()
-    {
-        $inaugurationDate = new \DateTime('2009-01-20', $this->timezone);
-        $this->assertNotEquals(true, count($this->holiday->isHoliday($inaugurationDate)) > 0, 'First Inauguration Barack Obama');
     }
 
     public function testFollowUpDayIsHoliday()

--- a/tests/Holiday/Us/UsMiTest.php
+++ b/tests/Holiday/Us/UsMiTest.php
@@ -68,7 +68,7 @@ class UsMiTest extends TestCase
         $newYears = new \DateTime('2023-01-01', $this->timezone);
         $newYearsFollowUp = new \DateTime('2023-01-02', $this->timezone);
 
-        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years Failed');
-        $this->assertEquals(false, count($this->holiday->isHoliday($newYearsFollowUp)) > 0, 'New Years Follow Up Failed');
+        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($newYearsFollowUp)) > 0, 'New Years Follow Up Day');
     }
 }

--- a/tests/Holiday/Us/UsMiTest.php
+++ b/tests/Holiday/Us/UsMiTest.php
@@ -47,20 +47,20 @@ class UsMiTest extends TestCase
 
         $dummyDate = new \DateTime('2015-03-11', $this->timezone);
 
-        $this->assertEquals(true, count($this->holiday->isHoliday($christmas)) > 0, 'Christmas Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($christmasEve)) > 0, 'Christmas Eve Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgiving)) > 0, 'Thanksgiving Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgivingAdamOrBlackFriday)) > 0, 'Black Friday Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($independenceDay)) > 0, 'Independence Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($martinLutherKingDay)) > 0, 'MLK Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($presidentsDay)) > 0, 'Presidents Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($memorialDay)) > 0, 'Memorial Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($juneteenthDay)) > 0, 'Juneteenth Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($laborDay)) > 0, 'Labor Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($veteransDay)) > 0, 'Veterans Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($columbusDay)) > 0, 'Columbus Day Failed');
-        $this->assertNotEquals(true, count($this->holiday->isHoliday($dummyDate)) > 0, 'Dummy Date Test Failed');
+        $this->assertEquals(true, count($this->holiday->isHoliday($christmas)) > 0, 'Christmas');
+        $this->assertEquals(true, count($this->holiday->isHoliday($christmasEve)) > 0, 'Christmas Eve');
+        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgiving)) > 0, 'Thanksgiving');
+        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgivingAdamOrBlackFriday)) > 0, 'Black Friday');
+        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years');
+        $this->assertEquals(true, count($this->holiday->isHoliday($independenceDay)) > 0, 'Independence Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($martinLutherKingDay)) > 0, 'MLK Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($presidentsDay)) > 0, 'Presidents Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($memorialDay)) > 0, 'Memorial Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($juneteenthDay)) > 0, 'Juneteenth Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($laborDay)) > 0, 'Labor Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($veteransDay)) > 0, 'Veterans Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($columbusDay)) > 0, 'Columbus Day');
+        $this->assertNotEquals(true, count($this->holiday->isHoliday($dummyDate)) > 0, 'Dummy Date Test');
     }
 
     public function testFollowUpDayIsHoliday()

--- a/tests/Holiday/Us/UsTest.php
+++ b/tests/Holiday/Us/UsTest.php
@@ -41,26 +41,24 @@ class UsTest extends TestCase
         $presidentsDay = new \DateTime('2015-02-16', $this->timezone);
         $memorialDay = new \DateTime('2015-05-25', $this->timezone);
         $juneteenthDay = new \DateTime('2021-06-19', $this->timezone);
-        $laborDay = new \DateTime('2014-09-01', $this->timezone);
         $veteransDay = new \DateTime('2014-11-11', $this->timezone);
         $columbusDay = new \DateTime('2014-10-13', $this->timezone);
 
         $dummyDate = new \DateTime('2015-03-11', $this->timezone);
 
-        $this->assertEquals(true, count($this->holiday->isHoliday($christmas)) > 0, 'Christmas Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($christmasEve)) > 0, 'Christmas Eve Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgiving)) > 0, 'Thanksgiving Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgivingAdamOrBlackFriday)) > 0, 'Black Friday Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($independenceDay)) > 0, 'Independence Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($martinLutherKingDay)) > 0, 'MLK Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($presidentsDay)) > 0, 'Presidents Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($memorialDay)) > 0, 'Memorial Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($juneteenthDay)) > 0, 'Juneteenth Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($laborDay)) > 0, 'Labor Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($veteransDay)) > 0, 'Veterans Day Failed');
-        $this->assertEquals(true, count($this->holiday->isHoliday($columbusDay)) > 0, 'Columbus Day Failed');
-        $this->assertNotEquals(true, count($this->holiday->isHoliday($dummyDate)) > 0, 'Dummy Date Test Failed');
+        $this->assertEquals(true, count($this->holiday->isHoliday($christmas)) > 0, 'Christmas');
+        $this->assertEquals(true, count($this->holiday->isHoliday($christmasEve)) > 0, 'Christmas Eve');
+        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgiving)) > 0, 'Thanksgiving');
+        $this->assertEquals(true, count($this->holiday->isHoliday($thanksgivingAdamOrBlackFriday)) > 0, 'Black Friday');
+        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years');
+        $this->assertEquals(true, count($this->holiday->isHoliday($independenceDay)) > 0, 'Independence Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($martinLutherKingDay)) > 0, 'MLK Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($presidentsDay)) > 0, 'Presidents Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($memorialDay)) > 0, 'Memorial Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($juneteenthDay)) > 0, 'Juneteenth Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($veteransDay)) > 0, 'Veterans Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($columbusDay)) > 0, 'Columbus Day');
+        $this->assertNotEquals(true, count($this->holiday->isHoliday($dummyDate)) > 0, 'Dummy Date Test');
     }
 
     public function testInaugurationIsNotAPublicHoliday()
@@ -72,6 +70,9 @@ class UsTest extends TestCase
 
     public function testLabourDay()
     {
+        $laborDayDate = new \DateTime('2014-09-01', $this->timezone);
+        $this->assertEquals(true, count($this->holiday->isHoliday($laborDayDate)) > 0, 'Labor Day');
+
         $laborDayDate = new \DateTime('2023-09-04', $this->timezone);
         $this->assertEquals(true, count($this->holiday->isHoliday($laborDayDate)) > 0, 'Labour Day');
     }

--- a/tests/Holiday/Us/UsTest.php
+++ b/tests/Holiday/Us/UsTest.php
@@ -65,8 +65,15 @@ class UsTest extends TestCase
 
     public function testInaugurationIsNotAPublicHoliday()
     {
+        // this date is not a public holiday in any state except Washington, DC
         $inaugurationDate = new \DateTime('2009-01-20', $this->timezone);
         $this->assertNotEquals(true, count($this->holiday->isHoliday($inaugurationDate)) > 0, 'First Inauguration Barack Obama');
+    }
+
+    public function testLabourDay()
+    {
+        $laborDayDate = new \DateTime('2023-09-04', $this->timezone);
+        $this->assertEquals(true, count($this->holiday->isHoliday($laborDayDate)) > 0, 'Labour Day');
     }
 
     public function testFollowUpDayIsHoliday()
@@ -74,7 +81,16 @@ class UsTest extends TestCase
         $newYears = new \DateTime('2023-01-01', $this->timezone);
         $newYearsFollowUp = new \DateTime('2023-01-02', $this->timezone);
 
-        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years Failed');
-        $this->assertEquals(false, count($this->holiday->isHoliday($newYearsFollowUp)) > 0, 'New Years Follow Up Failed');
+        $this->assertEquals(true, count($this->holiday->isHoliday($newYears)) > 0, 'New Years Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($newYearsFollowUp)) > 0, 'New Years Follow Up Day');
+    }
+
+    public function testPreviousDayIsHoliday()
+    {
+        $independenceDay = new \DateTime('2026-07-04', $this->timezone);
+        $independenceDayPreviousDay = new \DateTime('2026-07-03', $this->timezone);
+
+        $this->assertEquals(true, count($this->holiday->isHoliday($independenceDay)) > 0, 'Independence Day');
+        $this->assertEquals(true, count($this->holiday->isHoliday($independenceDayPreviousDay)) > 0, 'Independence Day Previous');
     }
 }


### PR DESCRIPTION
Fix us state classes causing circular reference
Add general test for state Michigan
Add new test for DC with inauguration dates (public holidays) Extend US test with inauguration (no public holiday)